### PR TITLE
Do not restore content offset after update if list is scrolled to the top to avoid empty gap

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -117,7 +117,14 @@ extension BaseChatViewController {
         }
         let diffY = newRefRect.minY - oldRefRect.minY
         let newContentOffsetY = collectionView.contentOffset.y + diffY
-        guard newContentOffsetY > collectionView.contentInset.top else { return }
+        let topContentInset = {
+            if #available(iOS 11.0, *) {
+                return collectionView.adjustedContentInset.top
+            } else {
+                return collectionView.contentInset.top
+            }
+        }()
+        guard newContentOffsetY > -topContentInset else { return }
         collectionView.contentOffset = CGPoint(x: 0, y: newContentOffsetY)
     }
 

--- a/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Scrolling.swift
@@ -116,7 +116,9 @@ extension BaseChatViewController {
             return
         }
         let diffY = newRefRect.minY - oldRefRect.minY
-        collectionView.contentOffset = CGPoint(x: 0, y: collectionView.contentOffset.y + diffY)
+        let newContentOffsetY = collectionView.contentOffset.y + diffY
+        guard newContentOffsetY > collectionView.contentInset.top else { return }
+        collectionView.contentOffset = CGPoint(x: 0, y: newContentOffsetY)
     }
 
     public func scrollToItem(withId itemId: String,


### PR DESCRIPTION
When first message in the list is removed, do not attempt to restore content offset to invalid value